### PR TITLE
Expose .len() and .count() methods with docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,8 +400,8 @@ impl<K: Eq + Hash, V, S: BuildHasher> TtlCache<K, V, S> {
     ///
     /// let mut cache = TtlCache::new(2);
     ///
-    /// cache.insert(1, "a", Duration::from_secs(20));
-    /// cache.insert(2, "b", Duration::from_millis(1));
+    /// cache.insert(1, "a", Duration::from_millis(1));
+    /// cache.insert(2, "b", Duration::from_secs(20));
     /// sleep(Duration::from_millis(10));
     /// assert_eq!(cache.len(), 2);
     pub fn len(&self) -> usize {


### PR DESCRIPTION
This exposes the `.len()` method with documentation on why people might not want to use it to address the previous comment of the method. It's still useful to calculate ram usage of the cache. I've also added a `.count()` method with documentation that it modifies the cache since it calls `.remove_expired()` before returning `self.map.len()`.

I've noticed remove_expired only works reliable if you set the same ttl for every entry, because only then the oldest entry is guaranteed to expire first. I've added this in a comment for `.count()` and `.remove_expired()`.

This resolves #4.