### PR TITLE
add get(), renew(), remove contains_key()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ttl_cache"
 version = "0.3.0"
-authors = ["Stu Small <stuart.alan.small@gmail.com>"]
+authors = ["Stu Small <stuart.alan.small@gmail.com>", "Kalle Samuels <ks@ks.ax>"]
 description = "A cache that will expire values after a TTL"
 repository = "https://github.com/stusmall/ttl_cache"
 documentation = "https://docs.rs/ttl_cache/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ impl<K: Eq + Hash, V> TtlCache<K, V> {
 
 impl<K: Eq + Hash, V, S: BuildHasher> TtlCache<K, V, S> {
     /// Creates an empty cache that can hold at most `capacity` items
-    /// that expire after `duration` with the given hash builder.
+    /// with the given hash builder.
     pub fn with_hasher(capacity: usize, hash_builder: S) -> Self {
         TtlCache {
             map: LinkedHashMap::with_hasher(hash_builder),
@@ -74,32 +74,6 @@ impl<K: Eq + Hash, V, S: BuildHasher> TtlCache<K, V, S> {
             since: Instant::now(),
         }
     }
-
-    /// Check if the cache contains the given key.
-    ///
-    /// # Examples
-    /// ```
-    /// use std::time::Duration;
-    /// use ttl_cache::TtlCache;
-    ///
-    /// let mut cache = TtlCache::new(10);
-    /// cache.insert(1,"a", Duration::from_secs(30));
-    /// assert_eq!(cache.contains_key(&1), true);
-    /// ```
-    pub fn contains_key<Q: ?Sized>(&mut self, key: &Q) -> bool
-        where K: Borrow<Q>,
-              Q: Hash + Eq
-    {
-        // Expiration check is handled by get_mut
-        let to_ret = self.get_mut(key).is_some();
-        if to_ret {
-            self.hits = self.hits.saturating_add(1);
-        } else {
-            self.misses = self.misses.saturating_add(1);
-        }
-        to_ret
-    }
-
 
     /// Inserts a key-value pair into the cache with an individual ttl for the key. If the key
     /// already existed and hasn't expired, the old value is returned.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -12,6 +12,8 @@ fn test_put_and_get() {
     cache.insert(2, 20, duration);
     assert_eq!(cache.get_mut(&1), Some(&mut 10));
     assert_eq!(cache.get_mut(&2), Some(&mut 20));
+    assert_eq!(cache.get(&1), Some(&10));
+    assert_eq!(cache.get(&2), Some(&20));
 }
 
 #[test]
@@ -24,20 +26,12 @@ fn test_put_update() {
 }
 
 #[test]
-fn test_contains_key() {
-    let duration = Duration::from_secs(60 * 60);
-    let mut cache = TtlCache::new(1);
-    cache.insert("1", 10, duration);
-    assert_eq!(cache.contains_key("1"), true);
-}
-
-#[test]
 fn test_expire_value() {
     let duration = Duration::from_millis(1);
     let mut cache = TtlCache::new(1);
     cache.insert("1", 10, duration);
     sleep(Duration::from_millis(10));
-    assert_eq!(cache.contains_key("1"), false);
+    assert_eq!(cache.get("1"), None);
 }
 
 #[test]
@@ -142,5 +136,15 @@ fn test() {
     cache.insert(3, 30, Duration::from_millis(300));
     sleep(Duration::from_millis(20));
     assert_eq!(cache.iter().collect::<Vec<_>>(), [(&1, &10), (&3, &30)]);
+}
 
+#[test]
+fn renewal_moves_to_end() {
+    let mut cache = TtlCache::new(3);
+    cache.insert(1,1, Duration::from_millis(300));
+    cache.insert(2,1, Duration::from_millis(300));
+    cache.renew(&1, Duration::from_millis(300));
+    let mut i = cache.iter();
+    assert_eq!(i.next(), Some((&2,&1)));
+    assert_eq!(i.next(), Some((&1,&1)));
 }


### PR DESCRIPTION
* I removed `contains_key`  because it can cause a race condition.
* make `fn iter()` non-mut, removing the expiration code in there. The intent is that an item shouldn't expire if you don't call a `mut` function. I believe that makes things easier to reason about.
* add an `fn get()`
* I think that `fn remove_expired()` can be entirely removed (not something I've done)
* add a `renew()` function that sets a new duration on a cache item. It intentionally can renew something that seems to have already expired, because you don't want a situation where you call get() and then not be able to renew it