### PR TITLE
Bump linked hashmap to 0.5.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["cache","ttl","expire"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-linked-hash-map = "0.5"
+linked-hash-map = "0.5.3"
 
 
 [features]


### PR DESCRIPTION
Older versions of linked-hashmap are unsound so it is better if this repository doesn't depend on those.

Advisory: RustSec/advisory-db#298