### PR TITLE
Require linked-hash-map v0.5.3 (or a newer patch version)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["cache","ttl","expire"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-linked-hash-map = "0.5"
+linked-hash-map = "~0.5.3"
 
 
 [features]


### PR DESCRIPTION
Hi @stusmall,
I found an issue with the linked_hash_map dependency on `<= v0.5.2`.  linked-hash-map can panic due to the UB checks implemented in Rust 1.48 (https://github.com/rust-lang/rust/issues/66151, as it uses std::mem::uninitialized: 

v0.5.3 fixes the issue (https://github.com/contain-rs/linked-hash-map/pull/100).  This PR adds a requirement on v0.5.3 (or a newer patch version).

