### PR TITLE
cargo: require at least linked-hash-map 0.5.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["cache","ttl","expire"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-linked-hash-map = "0.5"
+linked-hash-map = "0.5.3"
 
 
 [features]


### PR DESCRIPTION
This avoids RUSTSEC-2020-0026 in linked-hash-map for `-Z
minimal-versions` builds.

https://rustsec.org/advisories/RUSTSEC-2020-0026